### PR TITLE
Enable logging feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    secrets_parser (0.0.5)
+    secrets_parser (0.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -91,3 +91,19 @@ puts JSON.pretty_generate(parsed_file)
   }
 }
 ```
+
+### Logging
+
+To enable logging feature just configure `:logger` key injecting a logger that implements [Logger interface](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html).
+
+Sample using ruby's Logger stdlib:
+
+```
+require 'secrets_parser'
+require 'logger'
+
+parser = Secrets::Parser.new
+parser.set_config do |config|
+  config[:logger] = Logger.new(STDOUT)
+end
+```

--- a/lib/secrets_parser/version.rb
+++ b/lib/secrets_parser/version.rb
@@ -1,3 +1,3 @@
 module SecretsParser
-  VERSION = "0.0.5"
+  VERSION = "0.1.0"
 end

--- a/spec/fixtures/app.json
+++ b/spec/fixtures/app.json
@@ -5,8 +5,8 @@
     "required_services": [
     ],
     "variables": {
-      "MY_SECRET": "secret:flywire-playground-secrets/apps/secret-testing:my_secret",
-      "MY_SECRET2": "secret:$ACCOUNT_ALIAS-secrets/apps/secret-testing:my_secret",
+      "MY_SECRET": "secret:a-bucket/apps/secret-testing:my_secret",
+      "MY_SECRET2": "secret:a-bucket/apps/secret-testing:my_secret",
       "NOT_A_SECRET": 123,
       "NO_SECRETS_HERE": "PINCODE: Just joking"
     }

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,21 +1,53 @@
 require 'spec_helper'
+require 'logger'
 
 RSpec.describe Secrets::Parser do
-  describe '#parse' do
-    it 'returns parsed file with secrets' do
-      @parser = Secrets::Parser.new
-      stubbed_clients = stub_aws
-
-      @parser.set_config do |config|
-        config[:s3_client] = stubbed_clients[0]
-        config[:kms_client] = stubbed_clients[1]
+  describe 'as an operable artifact' do
+    it 'logs information when a logger is injected' do
+      logger = Logger.new(STDOUT)
+      parser = build_default_parser
+      parser.set_config do |config|
+        config[:logger] = logger
       end
 
-      ENV['ACCOUNT_ALIAS'] = 'flywire-playground'
+      expect(logger).to receive(:info).with("Parsing #{field} section of #{fixture}")
+      expect(logger).to receive(:info).with("Downloading #{secret_file} from #{bucket_name}")
+      secret_keys.each do |secret_key|
+        expect(logger).to receive(:info).with("Updating #{secret_key} value")
+      end
+
+      parser.parse(fixture, field)
+    end
+
+    def fixture
+      "#{Dir.pwd}/spec/fixtures/app.json"
+    end
+
+    def field
+      'variables'
+    end
+
+    def secret_file
+      'apps/secret-testing.json.encrypted'
+    end
+
+    def bucket_name
+      'a-bucket'
+    end
+
+    def secret_keys
+      %w(MY_SECRET MY_SECRET2)
+    end
+  end
+
+  describe '#parse' do
+    it 'returns parsed file with secrets' do
+      parser = build_default_parser
+
       fixture_path = "#{Dir.pwd}/spec/fixtures/app.json"
       field_to_parse = 'variables'
 
-      parsed_file = @parser.parse(fixture_path, field_to_parse)
+      parsed_file = parser.parse(fixture_path, field_to_parse)
 
       expected_parsed_file = {
         'type' => 'http',
@@ -33,5 +65,19 @@ RSpec.describe Secrets::Parser do
 
       expect(expected_parsed_file).to eq parsed_file
     end
+  end
+
+  def build_default_parser
+    ENV['AWS_DEFAULT_REGION'] = 'eu-west-1'
+
+    parser = Secrets::Parser.new
+    stubbed_clients = stub_aws
+
+    parser.set_config do |config|
+      config[:s3_client] = stubbed_clients[0]
+      config[:kms_client] = stubbed_clients[1]
+    end
+
+    parser
   end
 end


### PR DESCRIPTION
### Logging
 To enable logging feature just configure `:logger` key injecting a logger that implements [Logger interface](https://ruby-doc.org/stdlib-2.5.0/libdoc/logger/rdoc/Logger.html).

 Sample using ruby's Logger stdlib:

 ```
require 'secrets_parser'
require 'logger'
 parser = Secrets::Parser.new
parser.set_config do |config|
  config[:logger] = Logger.new(STDOUT)
end
```